### PR TITLE
Refresh on load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/userdata
+/presets
+/node_modules
+/.idea
+/LICENSE.txt
+/README.txt
+/bin
+/doc
+/package-lock.json
+/.project
+/.vscode

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -771,7 +771,19 @@ Top: function () {
         Api('rankedBroadcastFeed', {languages: /* drkchange */ (langDt.find('.lang').val() == 'all') ? ["ar","da","de","en","es","fi","fr","he","hy","id","it","ja","kk","ko","nb","pl","other","pt","ro","ru","sv","tr","uk","zh"] : [langDt.find('.lang').val()]}, refreshList(ranked, '<h3>Ranked</h3>'));
         Api('featuredBroadcastFeed', {}, refreshList(featured, '<h3>Featured</h3>'));
     });
-    $('#right').append($('<div id="Top"/>').append(langDt, button, featured, ranked));
+    var refreshOnLoad = $('<label><input id="topRefreshOnLoad" type="checkbox" checked="true"> Refresh on load</label>')
+
+    var TopObj = $('<div id="Top"/>').append(langDt, button, refreshOnLoad, featured, ranked);
+    $('#right').append(TopObj);
+
+    TopObj.on("show", function() {
+        if (!$("#topRefreshOnLoad")[0].checked)
+            return;
+
+        ScrollPositions["Top"] = 0;
+        button.click();
+    });
+
     button.click();
 },
 Search: function () {
@@ -921,7 +933,20 @@ Following2: function () {
     /* drkchange23 */filterBox.append(languagesFilter, hideEnded, hideProducer)
     /* drkchange23 */var filtersToggle = $('<a class="button" style="float:right">Filters</a></br>').click(function(){filterBox.toggle()});
 
-    $('#right').append($('<div id="Following2"/>').append(button, /* drkchange23 */filtersToggle, /* drkchange23 */filterBox, result));
+    var refreshOnLoad = $('<label><input id="following2RefreshOnLoad" type="checkbox" checked="true"> Refresh on load</label>')
+
+    var Following2Obj = $('<div id="Following2"/>');
+    Following2Obj.append(button, refreshOnLoad, /* drkchange23 */filtersToggle, /* drkchange23 */filterBox, result)
+
+    Following2Obj.on("show", function() {
+        if (!$("#topRefreshOnLoad")[0].checked)
+            return;
+
+        ScrollPositions["Following2"] = 0;
+        button.click();
+    });
+
+    $('#right').append(Following2Obj);
     button.click();
 },
 Create: function () {

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -771,7 +771,16 @@ Top: function () {
         Api('rankedBroadcastFeed', {languages: /* drkchange */ (langDt.find('.lang').val() == 'all') ? ["ar","da","de","en","es","fi","fr","he","hy","id","it","ja","kk","ko","nb","pl","other","pt","ro","ru","sv","tr","uk","zh"] : [langDt.find('.lang').val()]}, refreshList(ranked, '<h3>Ranked</h3>'));
         Api('featuredBroadcastFeed', {}, refreshList(featured, '<h3>Featured</h3>'));
     });
-    var refreshOnLoad = $('<label><input id="topRefreshOnLoad" type="checkbox" checked="true"> Refresh on load</label>')
+
+    if (!settings.topRefreshOnLoad)
+        setSet('topRefreshOnLoad', false);
+
+    var refreshOnLoadBtn = $('<input id="topRefreshOnLoad" type="checkbox">').change(function () {
+        setSet('topRefreshOnLoad', this.checked);
+    });
+    refreshOnLoadBtn.checked = settings.topRefreshOnLoad;
+
+    var refreshOnLoad = $('<label/>Refresh on load</label>').prepend(refreshOnLoadBtn);
 
     var TopObj = $('<div id="Top"/>').append(langDt, button, refreshOnLoad, featured, ranked);
     $('#right').append(TopObj);
@@ -933,13 +942,21 @@ Following2: function () {
     /* drkchange23 */filterBox.append(languagesFilter, hideEnded, hideProducer)
     /* drkchange23 */var filtersToggle = $('<a class="button" style="float:right">Filters</a></br>').click(function(){filterBox.toggle()});
 
-    var refreshOnLoad = $('<label><input id="following2RefreshOnLoad" type="checkbox" checked="true"> Refresh on load</label>')
+    if (!settings.following2RefreshOnLoad)
+        setSet('following2RefreshOnLoad', false);
+
+    var refreshOnLoadBtn = $('<input id="following2RefreshOnLoad" type="checkbox">').change(function () {
+        setSet('following2RefreshOnLoad', this.checked);
+    });
+    refreshOnLoadBtn.checked = settings.following2RefreshOnLoad;
+
+    var refreshOnLoad = $('<label> Refresh on load</label>').prepend(refreshOnLoadBtn);
 
     var Following2Obj = $('<div id="Following2"/>');
     Following2Obj.append(button, refreshOnLoad, /* drkchange23 */filtersToggle, /* drkchange23 */filterBox, result)
 
     Following2Obj.on("show", function() {
-        if (!$("#topRefreshOnLoad")[0].checked)
+        if (!$("#following2RefreshOnLoad")[0].checked)
             return;
 
         ScrollPositions["Following2"] = 0;

--- a/jquery.js
+++ b/jquery.js
@@ -4629,6 +4629,8 @@ function showHide( elements, show ) {
 			continue;
 		}
 
+		var events = jQuery._data(elem, "events");
+		var eventName = ""
 		display = elem.style.display;
 		if ( show ) {
 
@@ -4644,12 +4646,27 @@ function showHide( elements, show ) {
 			if ( elem.style.display === "" && isHiddenWithinTree( elem ) ) {
 				values[ index ] = getDefaultDisplay( elem );
 			}
+
+			eventName = "show";
 		} else {
 			if ( display !== "none" ) {
 				values[ index ] = "none";
 
 				// Remember what we're overwriting
 				dataPriv.set( elem, "display", display );
+			}
+
+			eventName = "hide";
+		}
+
+		// trigger event
+		if (events !== undefined && events[eventName] !== undefined)
+		{
+			var theseEvents = events[eventName];
+			var handlerLength = theseEvents.length;
+			for(var handlerIndex = 0 ; handlerIndex < handlerLength ; ++handlerIndex) 
+			{
+				theseEvents[handlerIndex].handler();
 			}
 		}
 	}


### PR DESCRIPTION
Background:
Top and Following are currently manually updated. The refresh button is at the top of the page and I had to scroll every time I need to refresh.

Solution:
make Top, Following pages refresh on show (or by clicking on the left panel button)
