### PR TITLE
Multiple preview windows

### DIFF
--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -1478,7 +1478,7 @@ User: function () {
                 user_id: id,
                 all: true
             }, function (broadcasts) {
-                refreshList($('#userBroadcasts'))(broadcasts);
+                refreshList($('#userBroadcasts'), null, "userBroadcasts")(broadcasts);
                 BroadcastsSpoiler.append(' (' + broadcasts.length + ')').click();
             }); /* drkchange26 */
         },function(response){resultUser.prepend(response)});
@@ -1908,7 +1908,8 @@ function refreshList(jcontainer, title, /* drkchange00 */ refreshFrom) {  // use
             for (var i in response) {
                 /* drkchange00 */ var newHighlight = mutualIDs(response, oldBroadcastsList).indexOf(response[i].id) < 0 && refreshFrom === 'following' && oldBroadcastsList.length !== 0 ? 'newHighlight' : '';/*drkchange00 end*/
                 var stream = $('<div class="card ' + response[i].state + ' ' + response[i].id + /* drkchange00 */ ' ' + newHighlight + /* drkchange00 */ '"/>').append(getDescription(response[i]));
-                addUserContextMenu(stream, response[i].user_id, response[i].username);
+                if (refreshFrom != "userBroadcasts")
+                    addUserContextMenu(stream, response[i].user_id, response[i].username);
                 
                 var link = $('<a>Get stream link</a>');
                 link.click(getM3U.bind(null, response[i].id, stream));

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -2524,6 +2524,48 @@ function getFlag(country) {
     var output = emoji.replace_unified(both);
     return (output === both) ? country : output;
 };
+function loadScreenPreviewer(stream, thumbs) {
+    /* drkchange01 */
+    var win = window.open("", "screenPreviewer", "toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=800,height=550,top=100,left="+(screen.width/2));
+    var title = '<title>'+(stream.status || 'Untitled')+' [My-OpenPeriscope]</title>';
+    var html = '<style type="text/css">.hideImages{display: none;}#screenPreviewer{height: 90%; position: absolute;left: 50% ;transform: translateX(-50%); -webkit-transform: translateX(-50%); border: 1px solid gray} body{background: #2A2A2A} a{color: white; display: block}</style>'
+        +'<a href="#" id="button">Switch to screenlist</a><div id="screenPreviewer"></div>';
+    for (var i in thumbs.chunks) {
+        html+='<img src="' + thumbs.chunks[i].tn + '"/>';
+    }
+    html+='<script>\
+    setTimeout(function () {\
+        var images = document.querySelectorAll("img");\
+        var widowWidth = (0.9 * window.innerWidth) || 720;\
+        var bg = document.getElementById("screenPreviewer");\
+        var lastI = 0;\
+        var button = document.getElementById("button");\
+        button.onclick = function () {\
+            bg.style.width = widowWidth;\
+            bg.style.display == "block" ? bg.style.display = "none" : bg.style.display = "block";\
+            for (var j = 0, len = images.length; j < len; j++)\
+            images[j].className == "hideImages" ? (images[j].className = "") : (images[j].className = "hideImages");\
+            var i = 0;\
+            bg.onmousemove = function (event) {\
+                i = Math.floor(event.offsetX / (widowWidth / len));\
+                if (i >= len) i = len;\
+                if (i < 1) i = 0;\
+                if (i != lastI) {\
+                    if (images[i].complete)\
+                    bg.style.background = "url(" + images[i].src + ") no-repeat center /contain";\
+                    lastI = i;\
+                }\
+            }\
+        }\
+    }, 100);\
+    setTimeout(function () {\
+        button.click();\
+    }, 200);\
+    </script>';
+    win.document.body.innerHTML = '';
+    win.document.write(title,html);
+
+}
 function getDescription(stream) {
     var title = emoji.replace_unified(stream.status || 'Untitled');
     var featured_reason = '';
@@ -2551,45 +2593,7 @@ function getDescription(stream) {
         Api('replayThumbnailPlaylist', {
             broadcast_id: stream.id
         }, function (thumbs) {
-            /* drkchange01 */
-            var win = window.open("", "screenPreviewer", "toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=800,height=550,top=100,left="+(screen.width/2));
-            var title = '<title>'+(stream.status || 'Untitled')+' [My-OpenPeriscope]</title>';
-            var html = '<style type="text/css">.hideImages{display: none;}#screenPreviewer{height: 90%; position: absolute;left: 50% ;transform: translateX(-50%); -webkit-transform: translateX(-50%); border: 1px solid gray} body{background: #2A2A2A} a{color: white; display: block}</style>'
-             +'<a href="#" id="button">Switch to screenlist</a><div id="screenPreviewer"></div>';
-            for (var i in thumbs.chunks) {
-                html+='<img src="' + thumbs.chunks[i].tn + '"/>';
-            }
-            html+='<script>\
-            setTimeout(function () {\
-                var images = document.querySelectorAll("img");\
-                var widowWidth = (0.9 * window.innerWidth) || 720;\
-                var bg = document.getElementById("screenPreviewer");\
-                var lastI = 0;\
-                var button = document.getElementById("button");\
-                button.onclick = function () {\
-                    bg.style.width = widowWidth;\
-                    bg.style.display == "block" ? bg.style.display = "none" : bg.style.display = "block";\
-                    for (var j = 0, len = images.length; j < len; j++)\
-                    images[j].className == "hideImages" ? (images[j].className = "") : (images[j].className = "hideImages");\
-                    var i = 0;\
-                    bg.onmousemove = function (event) {\
-                        i = Math.floor(event.offsetX / (widowWidth / len));\
-                        if (i >= len) i = len;\
-                        if (i < 1) i = 0;\
-                        if (i != lastI) {\
-                            if (images[i].complete)\
-                            bg.style.background = "url(" + images[i].src + ") no-repeat center /contain";\
-                            lastI = i;\
-                        }\
-                    }\
-                }\
-            }, 100);\
-            setTimeout(function () {\
-                button.click();\
-            }, 200);\
-            </script>';
-            win.document.body.innerHTML = '';
-            win.document.write(title,html);
+            loadScreenPreviewer(stream, thumbs);
         });
     });
     /* drkchange01 */var showImage = $('<a class="lastestImage"><img lazysrc="' + stream.image_url_small + '"/>' + (stream.is_locked ? '<img src="' + IMG_PATH + '/images/lock-white.png" class="lock"/>' : '') 

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -2525,8 +2525,8 @@ function getFlag(country) {
     return (output === both) ? country : output;
 };
 function loadScreenPreviewer(stream, thumbs) {
-    /* drkchange01 */
-    var win = window.open("", "screenPreviewer", "toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=800,height=550,top=100,left="+(screen.width/2));
+        /* drkchange01 */
+    var win = window.open("", "screenPreviewer" + stream.id, "toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=800,height=550,top=100,left="+(screen.width/2));
     var title = '<title>'+(stream.status || 'Untitled')+' [My-OpenPeriscope]</title>';
     var html = '<style type="text/css">.hideImages{display: none;}#screenPreviewer{height: 90%; position: absolute;left: 50% ;transform: translateX(-50%); -webkit-transform: translateX(-50%); border: 1px solid gray} body{background: #2A2A2A} a{color: white; display: block}</style>'
         +'<a href="#" id="button">Switch to screenlist</a><div id="screenPreviewer"></div>';

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -1687,6 +1687,9 @@ Edit: function () {
         /* drkchange03 */ var download_Selected = $('<label><input type="checkbox" style="margin-left: 1.5em;"' + (settings.selectedDownload ? 'checked' : '') + '/> Selected users broadcasts</label>').click(function (e) {
             setSet('selectedDownload', e.target.checked);
         });
+        var open_preview_in_separate_windows = $('<label><input type="checkbox" style="margin-left: 1.5em;"' + (settings.previewSeparateWindows ? 'checked' : '') + '/> Open previews in separate windows</label>').click(function (e) {
+            setSet('previewSeparateWindows', e.target.checked);
+        });
         var current_download_path = $('<dt style="margin-right: 10px;">' + settings.downloadPath + '</dt>');
         var download_path = $('<dt/>').append($('<input type="file" webkitdirectory directory/>').change(function () {
             setSet('downloadPath', $(this).val());
@@ -1735,7 +1738,8 @@ Edit: function () {
         download_private, '<br>',
         download_following, '<br>',
         download_shared, '<br>',
-        /* drkchange03 */ download_Selected, '<br><br>',
+        /* drkchange03 */ download_Selected, '<br>',
+        open_preview_in_separate_windows, '<br><br>',
         'Notifications refresh interval: ', notifications_interval ,' seconds','<br/><br/>',
         (NODEJS ? ['<dt>Downloads path:</dt>', current_download_path, download_path, '<br/><br/>'] : ''),
         /* drkchange11 */log_broadcasts_to_file,
@@ -2526,7 +2530,7 @@ function getFlag(country) {
 };
 function loadScreenPreviewer(stream, thumbs) {
         /* drkchange01 */
-    var win = window.open("", "screenPreviewer" + stream.id, "toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=800,height=550,top=100,left="+(screen.width/2));
+    var win = window.open("", "screenPreviewer" + (settings.previewSeparateWindows?stream.id:''), "toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=800,height=550,top=100,left="+(screen.width/2));
     var title = '<title>'+(stream.status || 'Untitled')+' [My-OpenPeriscope]</title>';
     var html = '<style type="text/css">.hideImages{display: none;}#screenPreviewer{height: 90%; position: absolute;left: 50% ;transform: translateX(-50%); -webkit-transform: translateX(-50%); border: 1px solid gray} body{background: #2A2A2A} a{color: white; display: block}</style>'
         +'<a href="#" id="button">Switch to screenlist</a><div id="screenPreviewer"></div>';


### PR DESCRIPTION
Problem: with only one recycled preview window, we lose the existing one when the new preview override it
Solution: append the broadcast id to the preview window id to have multiple - but non duplicate - previews

not related: fix to not show context menu in the user tab broadcasts