### PR TITLE
Apitest support http get

### DIFF
--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -762,7 +762,7 @@ ApiTest: function () {
                 params = '{}';
                 $('#params').text(params);
             }
-            ApiWorker(http_method, url_root, method, headers, JSON.parse(params), function (response) {
+            ApiWorker(http_method, url_root, method, JSON.parse(headers), JSON.parse(params), function (response) {
                 $('#response').html(JSON.stringify(response, null, 4));
             }, function (error) {
                 $('#response').text(error);
@@ -2776,7 +2776,6 @@ function ApiWorker(http_method, api_root, method, headers, params, callback, cal
         params.cookie = loginTwitter.cookie;
     Progress.start();
     var xhrIndex = XHR.length;
-    debugger;
     var req = GM_xmlhttpRequest({
         method: http_method,
         url: api_root + method,

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -547,7 +547,7 @@ var languageSelect = '<dt>Language: <select class="lang">\
             <option>all</option>\
         </select></dt>';
 function refreshProfile() {
-    Api(default_api_root, 'user', default_headers, {
+    Api('user', {
         user_id: loginTwitter.user.id
     }, function (userResponse) {
         loginTwitter.user = userResponse.user;
@@ -681,7 +681,7 @@ Map: function () {
         clearXHR();
         if (mapBounds._northEast.lat == mapBounds._southWest.lat && mapBounds._northEast.lng == mapBounds._southWest.lng)
             console.warn('Map is out of mind');
-        Api(default_api_root, 'mapGeoBroadcastFeed', default_headers, {
+        Api('mapGeoBroadcastFeed', {
             "include_replay": true,
             "p1_lat": mapBounds._northEast.lat,
             "p1_lng": mapBounds._northEast.lng,
@@ -761,7 +761,7 @@ ApiTest: function () {
                 params = '{}';
                 $('#params').text(params);
             }
-            Api(url_root, method, headers, JSON.parse(params), function (response) {
+            ApiWorker('POST', url_root, method, headers, JSON.parse(params), function (response) {
                 $('#response').html(JSON.stringify(response, null, 4));
             }, function (error) {
                 $('#response').text(error);
@@ -787,8 +787,8 @@ Top: function () {
     var langDt = $(languageSelect);
     langDt.find(":contains(" + (navigator.language || navigator.userLanguage || "en").substr(0, 2) + ")").attr("selected", "selected");
     var button = $('<a class="button" id="refreshTop">Refresh</a>').click(function () {
-        Api(default_api_root, 'rankedBroadcastFeed', default_headers, {languages: /* drkchange */ (langDt.find('.lang').val() == 'all') ? ["ar","da","de","en","es","fi","fr","he","hy","id","it","ja","kk","ko","nb","pl","other","pt","ro","ru","sv","tr","uk","zh"] : [langDt.find('.lang').val()]}, refreshList(ranked, '<h3>Ranked</h3>'));
-        Api(default_api_root, 'featuredBroadcastFeed', default_headers, {}, refreshList(featured, '<h3>Featured</h3>'));
+        Api('rankedBroadcastFeed', {languages: /* drkchange */ (langDt.find('.lang').val() == 'all') ? ["ar","da","de","en","es","fi","fr","he","hy","id","it","ja","kk","ko","nb","pl","other","pt","ro","ru","sv","tr","uk","zh"] : [langDt.find('.lang').val()]}, refreshList(ranked, '<h3>Ranked</h3>'));
+        Api('featuredBroadcastFeed', {}, refreshList(featured, '<h3>Featured</h3>'));
     });
 
     if (!settings.refreshTopOnLoad)
@@ -812,7 +812,7 @@ Search: function () {
     var searchBroadcast = function (query) {
         if (typeof query == 'string')
             input.val(query);
-        Api(default_api_root, 'broadcastSearch', default_headers, {
+        Api('broadcastSearch', {
             search: input.val(),
             include_replay: $('#includeReplays')[0].checked
         }, refreshList(searchResults, '<h3>Search results for '+input.val()+'</h3>'));
@@ -847,7 +847,7 @@ Search: function () {
     }
 
     function RefreshChannels() {
-        Api(default_api_root, 'authorizeToken', default_headers, {
+        Api('authorizeToken', {
             service: 'channels'
         }, function (authorizeToken) {
             authorization_token = authorizeToken.authorization_token;
@@ -862,7 +862,7 @@ Search: function () {
                             var ids = [];
                             for (var i in chan.Broadcasts)
                                 ids.push(chan.Broadcasts[i].BID);
-                            Api(default_api_root, 'getBroadcasts', default_headers, {
+                            Api('getBroadcasts', {
                                 broadcast_ids: ids,
                                 only_public_publish: true
                             }, refreshList(searchResults, '<h3>' + channelName + ', ' + chan.NLive + ' lives, ' + chan.NReplay + ' replays</h3>'));
@@ -999,7 +999,7 @@ Create: function () {
             widthInput.val(320);
         if (heightInput.val().trim() == '')
             heightInput.val(568);
-        Api(default_api_root, 'createBroadcast', default_headers, {
+        Api('createBroadcast', {
             lat: +$('#lat').val() || 0,
             lng: +$('#lon').val() || 0,
             //supports_psp_version: [1, 0, 0],
@@ -1007,7 +1007,7 @@ Create: function () {
             width: +widthInput.val(),
             height: +heightInput.val()
         }, function (createInfo) {
-            Api(default_api_root, 'publishBroadcast', default_headers, {
+            Api('publishBroadcast', {
                 broadcast_id: createInfo.broadcast.id,
                 friend_chat: $('#friend_chat')[0].checked,
                 has_location: true,
@@ -1228,7 +1228,7 @@ Chat: function () {
         title.empty();
         historyDiv.empty();
          //Load user list
-        Api(default_api_root, 'getBroadcastViewers', default_headers, {
+        Api('getBroadcastViewers', {
             broadcast_id: broadcast_id.val().trim()
         }, function(viewers){
             userlist.empty();
@@ -1238,7 +1238,7 @@ Chat: function () {
                     userlistAdd(user);
                 }
         });
-        Api(default_api_root, 'accessChannel', default_headers, {
+        Api('accessChannel', {
             broadcast_id: broadcast_id.val().trim()
         }, function (broadcast) {
             var userLink = $('<a class="username">(@' + broadcast.broadcast.username + ')</a>').click(switchSection.bind(null, 'User', broadcast.broadcast.user_id));
@@ -1483,13 +1483,13 @@ User: function () {
         /* drkchange26 */name.startsWith('@') ? (name = name.slice('1',name.length)) : '';
         /* drkchange26 */var param = {user_id : id};
         /* drkchange26 */name ? param = {username : name} : '' ;
-        Api(default_api_root, 'user', default_headers, param, function (response) {
+        Api('user', param, function (response) {
             /* drkchange26 */id = response.user.id;
             /* drkchange26 */$('#user_id').val(id);
             resultUser.prepend(getUserDescription(response.user));
             FollowersSpoiler.append(' (' + response.user.n_followers + ')');
             FollowingSpoiler.append(' (' + response.user.n_following + ')');
-            Api(default_api_root, 'userBroadcasts', default_headers, {
+            Api('userBroadcasts', {
                 user_id: id,
                 all: true
             }, function (broadcasts) {
@@ -1501,7 +1501,7 @@ User: function () {
         var FollowersSpoiler = $('<div class="spoiler menu" data-spoiler-link="followers">Followers</div>').on("jq-spoiler-visible", function() {
             var followersDiv = $('#userFollowers');
             if (!followersDiv.html())
-                Api(default_api_root, 'followers', default_headers, {
+                Api('followers', {
                     user_id: id
                 }, function (followers) {
                     if (followers.length){
@@ -1516,7 +1516,7 @@ User: function () {
         var FollowingSpoiler = $('<div class="spoiler menu" data-spoiler-link="following">Following</div>').on("jq-spoiler-visible", function() {
             var followingDiv = $('#userFollowing');
             if (!followingDiv.html())
-                Api(default_api_root, 'following', default_headers, {
+                Api('following', {
                     user_id: id
                 }, function (following) {
                     if (following.length){
@@ -1535,7 +1535,7 @@ User: function () {
             var BlockedSpoiler = $('<div class="spoiler menu" data-spoiler-link="blocked">Blocked</div>').on("jq-spoiler-visible", function() {
                 var blockedDiv = $('#userBlocked');
                 if (!blockedDiv.html())
-                    Api(default_api_root, 'block/users', default_headers, {}, function (blocked) {
+                    Api('block/users', {}, function (blocked) {
                         if (blocked.length)
                             for (var i in blocked) {
                                 blocked[i].is_blocked = true;
@@ -1554,7 +1554,7 @@ User: function () {
 },
 People: function () {
     var refreshButton = $('<a class="button">Refresh</a>').click(function () {
-        Api(default_api_root, 'suggestedPeople', default_headers, {
+        Api('suggestedPeople', {
             languages: [$('#People .lang').val()]
         }, function (response) {
             var result = $('#resultPeople');
@@ -1567,7 +1567,7 @@ People: function () {
             result.append('<h1>Popular</h1>');
             for (i in response.popular)
                 result.append($('<div class="card"/>').append(getUserDescription(response.popular[i])));
-            Api(default_api_root, 'suggestedPeople', default_headers, {}, function (response) {
+            Api('suggestedPeople', {}, function (response) {
                 if (response.hearted && response.hearted.length) {
                     result.append('<h1>Hearted</h1>');
                     for (var i in response.hearted)
@@ -1577,7 +1577,7 @@ People: function () {
         });
     });
     var searchPeople = function () {
-        Api(default_api_root, 'userSearch', default_headers, {
+        Api('userSearch', {
             search: $('#search').val()
         }, function (response) {
             var result = $('#resultPeople');
@@ -1589,7 +1589,7 @@ People: function () {
                     found_exact=true;
             }
             if (!found_exact)
-                Api(default_api_root, 'user', default_headers, {
+                Api('user', {
                     username: $('#search').val()
                 }, function (user) {
                     result.prepend($('<div class="card"/>').append(getUserDescription(user.user)));
@@ -1610,7 +1610,7 @@ Edit: function () {
     var button = $('<a class="button">Save</a>').click(function () {
         var uname = $('#uname').val();
         if (uname != loginTwitter.user.username) {
-            Api(default_api_root, 'verifyUsername', default_headers, {
+            Api('verifyUsername', {
                 username: uname,
                 display_name: loginTwitter.user.display_name
             }, function () {
@@ -1620,7 +1620,7 @@ Edit: function () {
         }
         var description = $('#description').val();
         if (description != loginTwitter.user.description)
-            Api(default_api_root, 'updateDescription', default_headers, {
+            Api('updateDescription', {
                 description: description
             }, function () {
                 loginTwitter.user.description = description;
@@ -1628,7 +1628,7 @@ Edit: function () {
             });
         var dname = $('#dname').val();
         if (dname != loginTwitter.user.display_name) {
-            Api(default_api_root, 'updateDisplayName', default_headers, {
+            Api('updateDisplayName', {
                 display_name: dname
             }, function () {
                 loginTwitter.user.display_name = dname;
@@ -1645,7 +1645,7 @@ Edit: function () {
 
     var settingsContainer = $('<div/>');
     var tempSettings;
-    Api(default_api_root, 'getSettings', default_headers, {}, function (settingsResponse) {
+    Api('getSettings', {}, function (settingsResponse) {
         loginTwitter.settings = settingsResponse;
         localStorage.setItem('loginTwitter', JSON.stringify(loginTwitter));
         tempSettings = settingsResponse;
@@ -1658,7 +1658,7 @@ Edit: function () {
         }
     });
     var buttonSettings = $('<a class="button">Save</a>').click(function () {
-        Api(default_api_root, 'setSettings', default_headers, {
+        Api('setSettings', {
             settings: tempSettings
         }, function (r) {
             if (r.success){
@@ -1864,24 +1864,24 @@ function addUserContextMenu(node, id, username) {
         ev.preventDefault();
         var contextmenu = $('<div class="contextmenu" style="top: ' + ev.pageY + 'px; left: ' + ev.pageX + 'px;"/>')
             .append($('<div>Follow</div>').click(function () {
-                Api(default_api_root, 'follow', default_headers, {
+                Api('follow', {
                     user_id: id
                 });
             }))
             .append($('<div>Unfollow</div>').click(function () {
-                Api(default_api_root, 'unfollow', default_headers, {
+                Api('unfollow', {
                     user_id: id
                 });
             }))
             .append('<div data-clipboard-text="https://periscope.tv/' + username + '">Copy profile URL</div>' +
                     '<div data-clipboard-text="' + id + '">Copy user ID</div>')
             .append($('<div>Block user</div>').click(function () {
-                Api(default_api_root, 'block/add', default_headers, {
+                Api('block/add', {
                     to: id
                 });
             }))
             .append($('<div>Unlock user</div>').click(function () {
-                Api(default_api_root, 'block/remove', default_headers, {
+                Api('block/remove', {
                     to: id
                 });
             }))
@@ -2105,7 +2105,7 @@ function refreshList(jcontainer, title, /* drkchange00 */ refreshFrom) {  // use
             }));
 
             if (typeof response[0].n_watching == 'undefined')
-                Api(default_api_root, 'getBroadcasts', default_headers, {
+                Api('getBroadcasts', {
                     broadcast_ids: ids,
                     only_public_publish: true
                 }, function (info) {
@@ -2356,8 +2356,8 @@ function getURL(id, callback, /* drkchange14 */partialReplay){
     };
     /* drkchange14 */partialReplay ? ( ApiParameters.replay_redirect = false, ApiParameters.latest_replay_playlist = true) : '';
    (function a(ApiParameters){//private replays correctly attach to their card.
-        Api(default_api_root, 'accessVideoPublic', default_headers, ApiParameters, getURLCallback, function(){
-            Api(default_api_root, 'accessChannel', default_headers, ApiParameters, getURLCallback) // private video case
+        Api('accessVideoPublic', ApiParameters, getURLCallback, function(){
+            Api('accessChannel', ApiParameters, getURLCallback) // private video case
         });
     })(ApiParameters)
 }
@@ -2552,13 +2552,13 @@ function getDescription(stream) {
     }
     if (stream.user_id == loginTwitter.user.id)
         var deleteLink = $('<a class="delete right icon" title="Delete"/>').click(function () {
-            Api(default_api_root, 'deleteBroadcast', default_headers, {broadcast_id: stream.id}, function (resp) {
+            Api('deleteBroadcast', {broadcast_id: stream.id}, function (resp) {
                 if (resp.success)
                     description.parent().remove();
             });
         });
     var screenlistLink = $('<a class="screenlist right icon">Preview</a>').click(function () {
-        Api(default_api_root, 'replayThumbnailPlaylist', default_headers, {
+        Api('replayThumbnailPlaylist', {
             broadcast_id: stream.id
         }, function (thumbs) {
             loadScreenPreviewer(stream, thumbs);
@@ -2600,7 +2600,7 @@ function getUserDescription(user) {
     .append($('<a class="button' + (user.is_following ? ' activated' : '') + '">' + (user.is_following ? 'unfollow' : 'follow') + '</a>').click(function () {
         var el = this;
         /* drkchange03 */var selectButton=$(el).next().next()
-        Api(default_api_root, el.innerHTML, default_headers, { // follow or unfollow
+        Api(el.innerHTML, { // follow or unfollow
             user_id: user.id
         }, function (r) {
             if (r.success) {
@@ -2617,7 +2617,7 @@ function getUserDescription(user) {
     }))
     .append($('<a class="button">' + (user.is_blocked ? 'unblock' : 'block') + '</a>').click(function () {
         var el = this;
-        Api(default_api_root, el.innerHTML == 'block' ? 'block/add' : 'block/remove', default_headers, {
+        Api(el.innerHTML == 'block' ? 'block/add' : 'block/remove', {
             to: user.id
             }, function (r) {
                 if (r.success)
@@ -2764,15 +2764,19 @@ function clearXHR() {   // abort all running XHR requests
 }
 /* LEVEL 0 */
 var XHR = [];
-function Api(api_root, method, headers, params, callback, callback_fail) {
-    if (!params)
+function Api(method, params, callback, callback_fail) {
+    ApiWorker('POST', default_api_root, method, default_headers, params, callback, callback_fail);
+}
+function ApiWorker(http_method, api_root, method, headers, params, callback, callback_fail) {
+        if (!params)
         params = {};
     if (loginTwitter && loginTwitter.cookie)
         params.cookie = loginTwitter.cookie;
     Progress.start();
     var xhrIndex = XHR.length;
+    debugger;
     var req = GM_xmlhttpRequest({
-        method: 'POST',
+        method: http_method,
         url: api_root + method,
         headers: headers,
         timeout: 10000,
@@ -2811,7 +2815,7 @@ function Api(api_root, method, headers, params, callback, callback_fail) {
     XHR.push(req);
 }
 function SignIn3(session_key, session_secret) {
-    Api(default_api_root, 'loginTwitter', default_headers, {
+    Api('loginTwitter', {
         "session_key": session_key,
         "session_secret": session_secret
     }, function (response) {
@@ -2819,7 +2823,7 @@ function SignIn3(session_key, session_secret) {
         loginTwitter = response;
         Ready(loginTwitter);
         if (!loginTwitter.user.username)    // User registration
-            Api(default_api_root, 'verifyUsername', default_headers, {
+            Api('verifyUsername', {
                 username: loginTwitter.suggested_username,
                 display_name: loginTwitter.user.display_name
             }, function (verified) {
@@ -2998,7 +3002,7 @@ function SignInSessionID()
     setSet('session_cookie', $('#secret').val());
     if (settings.session_cookie)
     {
-        Api(default_api_root, 'user', default_headers, { cookie: settings.session_cookie }, 
+        Api('user', { cookie: settings.session_cookie }, 
             function (userResponse) 
             {
                 loginTwitter = localStorage.getItem('loginTwitter');
@@ -3010,7 +3014,7 @@ function SignInSessionID()
                 loginTwitter.user.profile_image_urls.sort(function (a, b) {
                     return a.width * a.height - b.width * b.height;
                 });
-                Api(default_api_root, 'getSettings', default_headers, {}, 
+                Api('getSettings', {}, 
                     function (settingsResponse) 
                     {
                         loginTwitter.settings = settingsResponse;

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -752,6 +752,7 @@ ApiTest: function () {
             var url_root = $('#url_root').val().trim();
             if (url_root == '')
                 throw Error('url is empty');
+            var http_method = $('#http_method').val().trim();
             var method = $('#method').val().trim();
             var headers = $('#headers').val().trim();
             if (headers == '')
@@ -761,7 +762,7 @@ ApiTest: function () {
                 params = '{}';
                 $('#params').text(params);
             }
-            ApiWorker('POST', url_root, method, headers, JSON.parse(params), function (response) {
+            ApiWorker(http_method, url_root, method, headers, JSON.parse(params), function (response) {
                 $('#response').html(JSON.stringify(response, null, 4));
             }, function (error) {
                 $('#response').text(error);
@@ -775,6 +776,7 @@ ApiTest: function () {
             '<a href="https://github.com/gitnew2018/My-OpenPeriscope"><img style="position: absolute; top: 0; right: 0; border: 0;" src="' + IMG_PATH + '/images/forkme.png" alt="Fork me on GitHub"></a>' +
             'Some documentation can be found in <a href="http://static.pmmlabs.ru/OpenPeriscope" target="_blank">docs by @cjhbtn</a>' +
             '<br/><dt>Url</dt><iframe id="urlautocomplete" name="urlautocomplete" style="display: none;"></iframe><form target="urlautocomplete"><input id="url_root" type="text" value="https://api.periscope.tv/api/v2/" autocomplete="on"/></input></form><br/>' +
+            '<br/><dt>Http</dt><select id="http_method"><option value="POST" selected="selected">POST</option><option value="GET">GET</option></select><br/>' +
             '<br/><dt>Method</dt><iframe id="forautocomplete" name="forautocomplete" style="display: none;"></iframe><form target="forautocomplete"><input id="method" type="text" placeholder="mapGeoBroadcastFeed" autocomplete="on"/></form><br/>' +
             '<BR/><dt>Header</dt><textarea id="headers">'+JSON.stringify(default_headers, null, 4)+'</textarea><br/>' +
             '<dt>Parameters</dt><textarea id="params" placeholder=\'{"include_replay": true, "p1_lat": 1, "p1_lng": 2, "p2_lat": 3, "p2_lng": 4}\'/><br/><br/>'

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -33,6 +33,7 @@ var emoji = new EmojiConvertor();
 /* drkchange06 */var childProcesses=[]; //list of video downloading processes
 /* drkchange03 */var selectedDownloadList = localStorage.getItem('selectedUsersDownloadList') || "";
 NODEJS = typeof GM_xmlhttpRequest === 'undefined';
+var default_api_root = 'https://api.periscope.tv/api/v2/';
 var IMG_PATH = 'https://raw.githubusercontent.com/gitnew2018/My-OpenPeriscope/master';
 var settings = JSON.parse(localStorage.getItem('settings')) || {};
 if (NODEJS) {  // for NW.js
@@ -543,7 +544,7 @@ var languageSelect = '<dt>Language: <select class="lang">\
             <option>all</option>\
         </select></dt>';
 function refreshProfile() {
-    Api('user', {
+    Api(default_api_root, 'user', {
         user_id: loginTwitter.user.id
     }, function (userResponse) {
         loginTwitter.user = userResponse.user;
@@ -677,7 +678,7 @@ Map: function () {
         clearXHR();
         if (mapBounds._northEast.lat == mapBounds._southWest.lat && mapBounds._northEast.lng == mapBounds._southWest.lng)
             console.warn('Map is out of mind');
-        Api('mapGeoBroadcastFeed', {
+        Api(default_api_root, 'mapGeoBroadcastFeed', {
             "include_replay": true,
             "p1_lat": mapBounds._northEast.lat,
             "p1_lng": mapBounds._northEast.lng,
@@ -753,7 +754,7 @@ ApiTest: function () {
                 params = '{}';
                 $('#params').text(params);
             }
-            Api(method, JSON.parse(params), function (response) {
+            Api(default_api_root, method, JSON.parse(params), function (response) {
                 $('#response').html(JSON.stringify(response, null, 4));
             }, function (error) {
                 $('#response').text(error);
@@ -777,8 +778,8 @@ Top: function () {
     var langDt = $(languageSelect);
     langDt.find(":contains(" + (navigator.language || navigator.userLanguage || "en").substr(0, 2) + ")").attr("selected", "selected");
     var button = $('<a class="button" id="refreshTop">Refresh</a>').click(function () {
-        Api('rankedBroadcastFeed', {languages: /* drkchange */ (langDt.find('.lang').val() == 'all') ? ["ar","da","de","en","es","fi","fr","he","hy","id","it","ja","kk","ko","nb","pl","other","pt","ro","ru","sv","tr","uk","zh"] : [langDt.find('.lang').val()]}, refreshList(ranked, '<h3>Ranked</h3>'));
-        Api('featuredBroadcastFeed', {}, refreshList(featured, '<h3>Featured</h3>'));
+        Api(default_api_root, 'rankedBroadcastFeed', {languages: /* drkchange */ (langDt.find('.lang').val() == 'all') ? ["ar","da","de","en","es","fi","fr","he","hy","id","it","ja","kk","ko","nb","pl","other","pt","ro","ru","sv","tr","uk","zh"] : [langDt.find('.lang').val()]}, refreshList(ranked, '<h3>Ranked</h3>'));
+        Api(default_api_root, 'featuredBroadcastFeed', {}, refreshList(featured, '<h3>Featured</h3>'));
     });
 
     if (!settings.refreshTopOnLoad)
@@ -802,7 +803,7 @@ Search: function () {
     var searchBroadcast = function (query) {
         if (typeof query == 'string')
             input.val(query);
-        Api('broadcastSearch', {
+        Api(default_api_root, 'broadcastSearch', {
             search: input.val(),
             include_replay: $('#includeReplays')[0].checked
         }, refreshList(searchResults, '<h3>Search results for '+input.val()+'</h3>'));
@@ -837,7 +838,7 @@ Search: function () {
     }
 
     function RefreshChannels() {
-        Api('authorizeToken', {
+        Api(default_api_root, 'authorizeToken', {
             service: 'channels'
         }, function (authorizeToken) {
             authorization_token = authorizeToken.authorization_token;
@@ -852,7 +853,7 @@ Search: function () {
                             var ids = [];
                             for (var i in chan.Broadcasts)
                                 ids.push(chan.Broadcasts[i].BID);
-                            Api('getBroadcasts', {
+                            Api(default_api_root, 'getBroadcasts', {
                                 broadcast_ids: ids,
                                 only_public_publish: true
                             }, refreshList(searchResults, '<h3>' + channelName + ', ' + chan.NLive + ' lives, ' + chan.NReplay + ' replays</h3>'));
@@ -989,7 +990,7 @@ Create: function () {
             widthInput.val(320);
         if (heightInput.val().trim() == '')
             heightInput.val(568);
-        Api('createBroadcast', {
+        Api(default_api_root, 'createBroadcast', {
             lat: +$('#lat').val() || 0,
             lng: +$('#lon').val() || 0,
             //supports_psp_version: [1, 0, 0],
@@ -997,7 +998,7 @@ Create: function () {
             width: +widthInput.val(),
             height: +heightInput.val()
         }, function (createInfo) {
-            Api('publishBroadcast', {
+            Api(default_api_root, 'publishBroadcast', {
                 broadcast_id: createInfo.broadcast.id,
                 friend_chat: $('#friend_chat')[0].checked,
                 has_location: true,
@@ -1218,7 +1219,7 @@ Chat: function () {
         title.empty();
         historyDiv.empty();
          //Load user list
-        Api('getBroadcastViewers', {
+        Api(default_api_root, 'getBroadcastViewers', {
             broadcast_id: broadcast_id.val().trim()
         }, function(viewers){
             userlist.empty();
@@ -1228,7 +1229,7 @@ Chat: function () {
                     userlistAdd(user);
                 }
         });
-        Api('accessChannel', {
+        Api(default_api_root, 'accessChannel', {
             broadcast_id: broadcast_id.val().trim()
         }, function (broadcast) {
             var userLink = $('<a class="username">(@' + broadcast.broadcast.username + ')</a>').click(switchSection.bind(null, 'User', broadcast.broadcast.user_id));
@@ -1473,13 +1474,13 @@ User: function () {
         /* drkchange26 */name.startsWith('@') ? (name = name.slice('1',name.length)) : '';
         /* drkchange26 */var param = {user_id : id};
         /* drkchange26 */name ? param = {username : name} : '' ;
-        Api('user', param, function (response) {
+        Api(default_api_root, 'user', param, function (response) {
             /* drkchange26 */id = response.user.id;
             /* drkchange26 */$('#user_id').val(id);
             resultUser.prepend(getUserDescription(response.user));
             FollowersSpoiler.append(' (' + response.user.n_followers + ')');
             FollowingSpoiler.append(' (' + response.user.n_following + ')');
-            Api('userBroadcasts', {
+            Api(default_api_root, 'userBroadcasts', {
                 user_id: id,
                 all: true
             }, function (broadcasts) {
@@ -1491,7 +1492,7 @@ User: function () {
         var FollowersSpoiler = $('<div class="spoiler menu" data-spoiler-link="followers">Followers</div>').on("jq-spoiler-visible", function() {
             var followersDiv = $('#userFollowers');
             if (!followersDiv.html())
-                Api('followers', {
+                Api(default_api_root, 'followers', {
                     user_id: id
                 }, function (followers) {
                     if (followers.length){
@@ -1506,7 +1507,7 @@ User: function () {
         var FollowingSpoiler = $('<div class="spoiler menu" data-spoiler-link="following">Following</div>').on("jq-spoiler-visible", function() {
             var followingDiv = $('#userFollowing');
             if (!followingDiv.html())
-                Api('following', {
+                Api(default_api_root, 'following', {
                     user_id: id
                 }, function (following) {
                     if (following.length){
@@ -1525,7 +1526,7 @@ User: function () {
             var BlockedSpoiler = $('<div class="spoiler menu" data-spoiler-link="blocked">Blocked</div>').on("jq-spoiler-visible", function() {
                 var blockedDiv = $('#userBlocked');
                 if (!blockedDiv.html())
-                    Api('block/users', {}, function (blocked) {
+                    Api(default_api_root, 'block/users', {}, function (blocked) {
                         if (blocked.length)
                             for (var i in blocked) {
                                 blocked[i].is_blocked = true;
@@ -1544,7 +1545,7 @@ User: function () {
 },
 People: function () {
     var refreshButton = $('<a class="button">Refresh</a>').click(function () {
-        Api('suggestedPeople', {
+        Api(default_api_root, 'suggestedPeople', {
             languages: [$('#People .lang').val()]
         }, function (response) {
             var result = $('#resultPeople');
@@ -1557,7 +1558,7 @@ People: function () {
             result.append('<h1>Popular</h1>');
             for (i in response.popular)
                 result.append($('<div class="card"/>').append(getUserDescription(response.popular[i])));
-            Api('suggestedPeople', {}, function (response) {
+            Api(default_api_root, 'suggestedPeople', {}, function (response) {
                 if (response.hearted && response.hearted.length) {
                     result.append('<h1>Hearted</h1>');
                     for (var i in response.hearted)
@@ -1567,7 +1568,7 @@ People: function () {
         });
     });
     var searchPeople = function () {
-        Api('userSearch', {
+        Api(default_api_root, 'userSearch', {
             search: $('#search').val()
         }, function (response) {
             var result = $('#resultPeople');
@@ -1579,7 +1580,7 @@ People: function () {
                     found_exact=true;
             }
             if (!found_exact)
-                Api('user', {
+                Api(default_api_root, 'user', {
                     username: $('#search').val()
                 }, function (user) {
                     result.prepend($('<div class="card"/>').append(getUserDescription(user.user)));
@@ -1600,7 +1601,7 @@ Edit: function () {
     var button = $('<a class="button">Save</a>').click(function () {
         var uname = $('#uname').val();
         if (uname != loginTwitter.user.username) {
-            Api('verifyUsername', {
+            Api(default_api_root, 'verifyUsername', {
                 username: uname,
                 display_name: loginTwitter.user.display_name
             }, function () {
@@ -1610,7 +1611,7 @@ Edit: function () {
         }
         var description = $('#description').val();
         if (description != loginTwitter.user.description)
-            Api('updateDescription', {
+            Api(default_api_root, 'updateDescription', {
                 description: description
             }, function () {
                 loginTwitter.user.description = description;
@@ -1618,7 +1619,7 @@ Edit: function () {
             });
         var dname = $('#dname').val();
         if (dname != loginTwitter.user.display_name) {
-            Api('updateDisplayName', {
+            Api(default_api_root, 'updateDisplayName', {
                 display_name: dname
             }, function () {
                 loginTwitter.user.display_name = dname;
@@ -1635,7 +1636,7 @@ Edit: function () {
 
     var settingsContainer = $('<div/>');
     var tempSettings;
-    Api('getSettings', {}, function (settingsResponse) {
+    Api(default_api_root, 'getSettings', {}, function (settingsResponse) {
         loginTwitter.settings = settingsResponse;
         localStorage.setItem('loginTwitter', JSON.stringify(loginTwitter));
         tempSettings = settingsResponse;
@@ -1648,7 +1649,7 @@ Edit: function () {
         }
     });
     var buttonSettings = $('<a class="button">Save</a>').click(function () {
-        Api('setSettings', {
+        Api(default_api_root, 'setSettings', {
             settings: tempSettings
         }, function (r) {
             if (r.success){
@@ -1854,24 +1855,24 @@ function addUserContextMenu(node, id, username) {
         ev.preventDefault();
         var contextmenu = $('<div class="contextmenu" style="top: ' + ev.pageY + 'px; left: ' + ev.pageX + 'px;"/>')
             .append($('<div>Follow</div>').click(function () {
-                Api('follow', {
+                Api(default_api_root, 'follow', {
                     user_id: id
                 });
             }))
             .append($('<div>Unfollow</div>').click(function () {
-                Api('unfollow', {
+                Api(default_api_root, 'unfollow', {
                     user_id: id
                 });
             }))
             .append('<div data-clipboard-text="https://periscope.tv/' + username + '">Copy profile URL</div>' +
                     '<div data-clipboard-text="' + id + '">Copy user ID</div>')
             .append($('<div>Block user</div>').click(function () {
-                Api('block/add', {
+                Api(default_api_root, 'block/add', {
                     to: id
                 });
             }))
             .append($('<div>Unlock user</div>').click(function () {
-                Api('block/remove', {
+                Api(default_api_root, 'block/remove', {
                     to: id
                 });
             }))
@@ -2095,7 +2096,7 @@ function refreshList(jcontainer, title, /* drkchange00 */ refreshFrom) {  // use
             }));
 
             if (typeof response[0].n_watching == 'undefined')
-                Api('getBroadcasts', {
+                Api(default_api_root, 'getBroadcasts', {
                     broadcast_ids: ids,
                     only_public_publish: true
                 }, function (info) {
@@ -2346,8 +2347,8 @@ function getURL(id, callback, /* drkchange14 */partialReplay){
     };
     /* drkchange14 */partialReplay ? ( ApiParameters.replay_redirect = false, ApiParameters.latest_replay_playlist = true) : '';
    (function a(ApiParameters){//private replays correctly attach to their card.
-        Api('accessVideoPublic', ApiParameters, getURLCallback, function(){
-            Api('accessChannel', ApiParameters, getURLCallback) // private video case
+        Api(default_api_root, 'accessVideoPublic', ApiParameters, getURLCallback, function(){
+            Api(default_api_root, 'accessChannel', ApiParameters, getURLCallback) // private video case
         });
     })(ApiParameters)
 }
@@ -2542,13 +2543,13 @@ function getDescription(stream) {
     }
     if (stream.user_id == loginTwitter.user.id)
         var deleteLink = $('<a class="delete right icon" title="Delete"/>').click(function () {
-            Api('deleteBroadcast', {broadcast_id: stream.id}, function (resp) {
+            Api(default_api_root, 'deleteBroadcast', {broadcast_id: stream.id}, function (resp) {
                 if (resp.success)
                     description.parent().remove();
             });
         });
     var screenlistLink = $('<a class="screenlist right icon">Preview</a>').click(function () {
-        Api('replayThumbnailPlaylist', {
+        Api(default_api_root, 'replayThumbnailPlaylist', {
             broadcast_id: stream.id
         }, function (thumbs) {
             loadScreenPreviewer(stream, thumbs);
@@ -2590,7 +2591,7 @@ function getUserDescription(user) {
     .append($('<a class="button' + (user.is_following ? ' activated' : '') + '">' + (user.is_following ? 'unfollow' : 'follow') + '</a>').click(function () {
         var el = this;
         /* drkchange03 */var selectButton=$(el).next().next()
-        Api(el.innerHTML, { // follow or unfollow
+        Api(default_api_root, el.innerHTML, { // follow or unfollow
             user_id: user.id
         }, function (r) {
             if (r.success) {
@@ -2607,7 +2608,7 @@ function getUserDescription(user) {
     }))
     .append($('<a class="button">' + (user.is_blocked ? 'unblock' : 'block') + '</a>').click(function () {
         var el = this;
-        Api(el.innerHTML == 'block' ? 'block/add' : 'block/remove', {
+        Api(default_api_root, el.innerHTML == 'block' ? 'block/add' : 'block/remove', {
             to: user.id
             }, function (r) {
                 if (r.success)
@@ -2754,7 +2755,7 @@ function clearXHR() {   // abort all running XHR requests
 }
 /* LEVEL 0 */
 var XHR = [];
-function Api(method, params, callback, callback_fail) {
+function Api(api_root, method, params, callback, callback_fail) {
     if (!params)
         params = {};
     if (loginTwitter && loginTwitter.cookie)
@@ -2763,7 +2764,7 @@ function Api(method, params, callback, callback_fail) {
     var xhrIndex = XHR.length;
     var req = GM_xmlhttpRequest({
         method: 'POST',
-        url: 'https://api.periscope.tv/api/v2/' + method,
+        url: api_root + method,
         headers: {
             'User-Agent': 'Periscope/2699 (iPhone; iOS 8.1.2; Scale/2.00)'
         },
@@ -2803,7 +2804,7 @@ function Api(method, params, callback, callback_fail) {
     XHR.push(req);
 }
 function SignIn3(session_key, session_secret) {
-    Api('loginTwitter', {
+    Api(default_api_root, 'loginTwitter', {
         "session_key": session_key,
         "session_secret": session_secret
     }, function (response) {
@@ -2811,7 +2812,7 @@ function SignIn3(session_key, session_secret) {
         loginTwitter = response;
         Ready(loginTwitter);
         if (!loginTwitter.user.username)    // User registration
-            Api('verifyUsername', {
+            Api(default_api_root, 'verifyUsername', {
                 username: loginTwitter.suggested_username,
                 display_name: loginTwitter.user.display_name
             }, function (verified) {
@@ -2990,7 +2991,7 @@ function SignInSessionID()
     setSet('session_cookie', $('#secret').val());
     if (settings.session_cookie)
     {
-        Api('user', { cookie: settings.session_cookie }, 
+        Api(default_api_root, 'user', { cookie: settings.session_cookie }, 
             function (userResponse) 
             {
                 loginTwitter = localStorage.getItem('loginTwitter');
@@ -3002,7 +3003,7 @@ function SignInSessionID()
                 loginTwitter.user.profile_image_urls.sort(function (a, b) {
                     return a.width * a.height - b.width * b.height;
                 });
-                Api('getSettings', {}, 
+                Api(default_api_root, 'getSettings', {}, 
                     function (settingsResponse) 
                     {
                         loginTwitter.settings = settingsResponse;

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -773,7 +773,7 @@ ApiTest: function () {
         $('<div id="ApiTest"/>').append(
             '<a href="https://github.com/gitnew2018/My-OpenPeriscope"><img style="position: absolute; top: 0; right: 0; border: 0;" src="' + IMG_PATH + '/images/forkme.png" alt="Fork me on GitHub"></a>' +
             'Some documentation can be found in <a href="http://static.pmmlabs.ru/OpenPeriscope" target="_blank">docs by @cjhbtn</a>' +
-            '<br/><dt>Url</dt><iframe id="urlautocomplete" name="urlautocomplete" style="display: none;"></iframe><form target="urlautocomplete"><input id="url_root" type="text" value="https://api.periscope.tv/api/v2/" autocomplete="on"/></input></form><br/>' +
+            '<br/><dt>Url</dt><iframe id="urlautocomplete" name="urlautocomplete" style="display: none;"></iframe><form target="urlautocomplete"><input id="url_root" type="text" value="https://api.periscope.tv/api/v2/" autocomplete="on"/></input></form>' +
             '<br/><dt>Http</dt><select id="http_method">'+
                 '<option value="POST" selected="selected">POST</option>'+ // The POST method is used to submit an entity to the specified resource, often causing a change in state or side effects on the server.
                 '<option value="GET">GET</option>'+                       // The GET method requests a representation of the specified resource. Requests using GET should only retrieve data.
@@ -784,8 +784,8 @@ ApiTest: function () {
                 '<option value="OPTIONS">OPTIONS</option>'+               // The OPTIONS method is used to describe the communication options for the target resource.
                 '<option value="TRACE">TRACE</option>'+                   // The TRACE method performs a message loop-back test along the path to the target resource.
                 '<option value="PATCH">PATCH</option></select><br/>' +    // The PATCH method is used to apply partial modifications to a resource.   
-            '<br/><dt>Method</dt><iframe id="forautocomplete" name="forautocomplete" style="display: none;"></iframe><form target="forautocomplete"><input id="method" type="text" placeholder="mapGeoBroadcastFeed" autocomplete="on"/></form><br/>' +
-            '<BR/><dt>Header</dt><textarea id="headers">'+JSON.stringify(default_headers, null, 4)+'</textarea><br/>' +
+            '<br/><dt>Method</dt><iframe id="forautocomplete" name="forautocomplete" style="display: none;"></iframe><form target="forautocomplete"><input id="method" type="text" placeholder="mapGeoBroadcastFeed" autocomplete="on"/></form>' +
+            '<br/><dt>Header</dt><textarea id="headers">'+JSON.stringify(default_headers, null, 4)+'</textarea><br/>' +
             '<dt>Parameters</dt><textarea id="params" placeholder=\'{"include_replay": true, "p1_lat": 1, "p1_lng": 2, "p2_lat": 3, "p2_lng": 4}\'/><br/><br/>'
             , submitButton, '<br/><br/><pre id="response"/>Response is also displayed in the browser console, if [Debug mode] is checked</pre>')
     );

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -774,7 +774,16 @@ ApiTest: function () {
             '<a href="https://github.com/gitnew2018/My-OpenPeriscope"><img style="position: absolute; top: 0; right: 0; border: 0;" src="' + IMG_PATH + '/images/forkme.png" alt="Fork me on GitHub"></a>' +
             'Some documentation can be found in <a href="http://static.pmmlabs.ru/OpenPeriscope" target="_blank">docs by @cjhbtn</a>' +
             '<br/><dt>Url</dt><iframe id="urlautocomplete" name="urlautocomplete" style="display: none;"></iframe><form target="urlautocomplete"><input id="url_root" type="text" value="https://api.periscope.tv/api/v2/" autocomplete="on"/></input></form><br/>' +
-            '<br/><dt>Http</dt><select id="http_method"><option value="POST" selected="selected">POST</option><option value="GET">GET</option></select><br/>' +
+            '<br/><dt>Http</dt><select id="http_method">'+
+                '<option value="POST" selected="selected">POST</option>'+ // The POST method is used to submit an entity to the specified resource, often causing a change in state or side effects on the server.
+                '<option value="GET">GET</option>'+                       // The GET method requests a representation of the specified resource. Requests using GET should only retrieve data.
+                '<option value="HEAD">HEAD</option>'+                     // The HEAD method asks for a response identical to that of a GET request, but without the response body.
+                '<option value="PUT">PUT</option>'+                       // The PUT method replaces all current representations of the target resource with the request payload.
+                '<option value="DELETE">DELETE</option>'+                 // The DELETE method deletes the specified resource.
+                '<option value="CONNECT">CONNECT</option>'+               // The CONNECT method establishes a tunnel to the server identified by the target resource.
+                '<option value="OPTIONS">OPTIONS</option>'+               // The OPTIONS method is used to describe the communication options for the target resource.
+                '<option value="TRACE">TRACE</option>'+                   // The TRACE method performs a message loop-back test along the path to the target resource.
+                '<option value="PATCH">PATCH</option></select><br/>' +    // The PATCH method is used to apply partial modifications to a resource.   
             '<br/><dt>Method</dt><iframe id="forautocomplete" name="forautocomplete" style="display: none;"></iframe><form target="forautocomplete"><input id="method" type="text" placeholder="mapGeoBroadcastFeed" autocomplete="on"/></form><br/>' +
             '<BR/><dt>Header</dt><textarea id="headers">'+JSON.stringify(default_headers, null, 4)+'</textarea><br/>' +
             '<dt>Parameters</dt><textarea id="params" placeholder=\'{"include_replay": true, "p1_lat": 1, "p1_lng": 2, "p2_lat": 3, "p2_lng": 4}\'/><br/><br/>'

--- a/Periscope_Web_Client.user.js
+++ b/Periscope_Web_Client.user.js
@@ -755,8 +755,6 @@ ApiTest: function () {
             var http_method = $('#http_method').val().trim();
             var method = $('#method').val().trim();
             var headers = $('#headers').val().trim();
-            if (headers == '')
-                throw Error('headers are empty');
             var params = $('#params').val().trim();
             if (params == '') {
                 params = '{}';


### PR DESCRIPTION
In order to properly test support for groups, this refactor to the `ApiTest` section will allow `v1` HTTP `GET` style calls..

Test get channels:

- Get authorization_token with `v2`
  - func: authorizeToken
  - param: {"service":"channels"}
- Get Channels with `v1`
  - url: https://channels.periscope.tv/v1/channels
  - HTML mthod `GET`
  - empty method, and params
  - copy the `authorization_token` to :
```JSON
headers: {
    "Authorization": "***", 
    "X-Periscope-User-Agent": "Periscope/2699 (iPhone; iOS 8.1.2; Scale/2.00)",
    "locale":"en"
}
```
  - run; you will get the broadcast channels

![GET-API](https://user-images.githubusercontent.com/49573478/62839866-f030b500-bc45-11e9-91dd-9f1a59300e58.JPG)
